### PR TITLE
Add screen monitor script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-"# pubg-overlay" 
+# PUBG Overlay Monitor
+
+This project provides a small desktop application that monitors the top-right corner of the screen, reads any text that appears there, and logs changes.
+
+## Requirements
+
+- Python 3.8+
+- `pyautogui`
+- `pytesseract`
+- `pillow`
+- Tesseract OCR engine (e.g., `sudo apt-get install tesseract-ocr`)
+
+Install the dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the monitor from a terminal:
+
+```bash
+python monitor_top_right.py
+```
+
+### Options
+
+- `--width`: width of the region to capture (default: 300)
+- `--height`: height of the region to capture (default: 200)
+- `--interval`: seconds between captures (default: 1.0)
+- `--log`: file to log detected text (default: `text_log.txt`)
+- `--tesseract`: path to the Tesseract executable (defaults to `TESSERACT_CMD` env var if set)
+
+Press `Ctrl+C` in the terminal to stop the monitoring.

--- a/monitor_top_right.py
+++ b/monitor_top_right.py
@@ -1,0 +1,66 @@
+import time
+import logging
+import argparse
+from typing import Tuple
+
+import os
+import pyautogui
+from PIL import Image
+import pytesseract
+
+
+def get_screen_region(width: int, height: int) -> Tuple[int, int, int, int]:
+    screen_width, screen_height = pyautogui.size()
+    left = max(screen_width - width, 0)
+    top = 0
+    return left, top, width, height
+
+
+def capture_region(region: Tuple[int, int, int, int]) -> Image.Image:
+    """Capture a region of the screen."""
+    screenshot = pyautogui.screenshot(region=region)
+    return screenshot
+
+
+def extract_text(image: Image.Image) -> str:
+    """Extract text from image using pytesseract."""
+    return pytesseract.image_to_string(image)
+
+
+def monitor(width: int, height: int, interval: float, log_file: str, tesseract_cmd: str) -> None:
+    if tesseract_cmd:
+        pytesseract.pytesseract.tesseract_cmd = tesseract_cmd
+    logging.basicConfig(filename=log_file, level=logging.INFO,
+                        format="%(asctime)s %(message)s")
+    region = get_screen_region(width, height)
+    previous_text = ""
+    logging.info("Monitoring started. Region: %s", region)
+    print(f"Monitoring region: {region}. Press Ctrl+C to stop.")
+    try:
+        while True:
+            image = capture_region(region)
+            text = extract_text(image).strip()
+            if text != previous_text:
+                logging.info("Text changed: %s", text)
+                print(f"Text changed: {text}")
+                previous_text = text
+            time.sleep(interval)
+    except KeyboardInterrupt:
+        print("Monitoring stopped.")
+        logging.info("Monitoring stopped by user.")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Monitor top-right corner of screen and log text changes.")
+    parser.add_argument("--width", type=int, default=300, help="Width of region to capture (pixels)")
+    parser.add_argument("--height", type=int, default=200, help="Height of region to capture (pixels)")
+    parser.add_argument("--interval", type=float, default=1.0, help="Seconds between captures")
+    parser.add_argument("--log", type=str, default="text_log.txt", help="File to log detected text")
+    parser.add_argument("--tesseract", type=str, default=os.getenv('TESSERACT_CMD', ''),
+                        help="Path to tesseract executable (optional)")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    monitor(args.width, args.height, args.interval, args.log, args.tesseract)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pyautogui
+pytesseract
+pillow


### PR DESCRIPTION
## Summary
- add a script to capture the top-right region of the screen
- log any detected text
- document usage and dependencies
- add tesseract executable path option for flexibility

## Testing
- `python -m py_compile monitor_top_right.py`
